### PR TITLE
fix(wrangler): only set environment if defined

### DIFF
--- a/examples/nuxt/nuxt.config.ts
+++ b/examples/nuxt/nuxt.config.ts
@@ -3,3 +3,4 @@ export default defineNuxtConfig({
   modules: ["nitro-cloudflare-dev"],
   compatibilityDate: "2024-10-10",
 });
+

--- a/examples/nuxt/nuxt.config.ts
+++ b/examples/nuxt/nuxt.config.ts
@@ -1,5 +1,5 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   modules: ["nitro-cloudflare-dev"],
-  compatibilityDate: "2024-10-10"
+  compatibilityDate: "2024-10-10",
 });

--- a/examples/nuxt/nuxt.config.ts
+++ b/examples/nuxt/nuxt.config.ts
@@ -1,5 +1,5 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   modules: ["nitro-cloudflare-dev"],
-  compatibilityDate: "2024-10-10",
+  compatibilityDate: "2024-10-10"
 });

--- a/examples/nuxt/nuxt.config.ts
+++ b/examples/nuxt/nuxt.config.ts
@@ -3,4 +3,3 @@ export default defineNuxtConfig({
   modules: ["nitro-cloudflare-dev"],
   compatibilityDate: "2024-10-10",
 });
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ async function nitroModule(nitro: Nitro) {
 // Dual compatibility with Nuxt and Nitro Modules
 export default function nitroCloudflareDev(arg1: unknown, arg2: unknown) {
   if ((arg2 as Nuxt)?.options?.nitro) {
-    (arg2 as Nuxt).hooks.hook("nitro:config", (nitroConfig) => {
+    (arg2 as Nuxt).hooks.hookOnce("nitro:config", (nitroConfig) => {
       nitroConfig.modules = nitroConfig.modules || [];
       nitroConfig.modules.push(nitroModule);
     });

--- a/src/runtime/plugin.dev.ts
+++ b/src/runtime/plugin.dev.ts
@@ -1,5 +1,5 @@
 import type { NitroAppPlugin } from "nitropack";
-import type { PlatformProxy } from "wrangler";
+import type { GetPlatformProxyOptions, PlatformProxy } from "wrangler";
 // @ts-ignore
 import { useRuntimeConfig, getRequestURL } from "#imports";
 
@@ -71,11 +71,14 @@ async function _getPlatformProxy() {
     };
   } = useRuntimeConfig();
 
-  const proxy = await getPlatformProxy({
+  const proxyOptions: GetPlatformProxyOptions = {
     configPath: runtimeConfig.wrangler.configPath,
     persist: { path: runtimeConfig.wrangler.persistDir },
-    environment: runtimeConfig.wrangler.environment,
-  });
+  };
+  if (runtimeConfig.wrangler.environment) {
+    proxyOptions.environment = runtimeConfig.wrangler.environment;
+  }
+  const proxy = await getPlatformProxy(proxyOptions);
 
   return proxy;
 }

--- a/src/runtime/plugin.dev.ts
+++ b/src/runtime/plugin.dev.ts
@@ -75,6 +75,8 @@ async function _getPlatformProxy() {
     configPath: runtimeConfig.wrangler.configPath,
     persist: { path: runtimeConfig.wrangler.persistDir },
   };
+  // TODO: investigate why
+  // https://github.com/pi0/nitro-cloudflare-dev/issues/51
   if (runtimeConfig.wrangler.environment) {
     proxyOptions.environment = runtimeConfig.wrangler.environment;
   }


### PR DESCRIPTION
resolves https://github.com/nuxt-hub/core/issues/331

I noticed that using `experiment.inlineRouteRules: true` create this issue for wrangler, making the bindings unavailable:
![CleanShot 2024-10-21 at 14 38 32@2x](https://github.com/user-attachments/assets/eff80154-22a5-4c76-95dd-223ffa2f657c)

When setting the flag, it seems the `runtimeConfig.wrangler.environment === ''` and the platform proxy does not like it, I updated so it is given only if set.

I also move from `hook` to `hookOnce` to avoid keeping a watcher.