### PR TITLE
Clarify module is no longer required for latest Nuxt/Nitro projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 > [!WARNING]
 > **This module is no longer required for the latest versions of Nitro.**
 > 
-> Latest versions of Nitro (v2 and v3) now include built-in support for Cloudflare development emulation, making this proof-of-concept module obsolete.
+> Latest versions of Nitro now include built-in support for Cloudflare development emulation. Please check [docs](https://nitro.build/deploy/providers/cloudflare#dev-preset) for more info.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+> [!WARNING]
+> **This module is no longer required for the latest versions of Nitro.**
+> 
+> Latest versions of Nitro (v2 and v3) now include built-in support for Cloudflare development emulation, making this proof-of-concept module obsolete.
+
+---
+
 # Cloudflare Platform for Nitro and Nuxt
 
 This proof of concept module enables access to the Cloudflare runtime platform in the development server of [Nitro](https://nitro.unjs.io) and [Nuxt](https://nuxt.com) using the [new `getPlatformProxy` API](https://github.com/cloudflare/workers-sdk/pull/5002) exposed by [wrangler](https://developers.cloudflare.com/workers/wrangler/) and [miniflare](https://miniflare.dev/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> [!WARNING]
+> [!IMPORTANT]
 > **This module is no longer required for the latest versions of Nitro.**
 > 
 > Latest versions of Nitro now include built-in support for Cloudflare development emulation. Please check [docs](https://nitro.build/deploy/providers/cloudflare#dev-preset) for more info.


### PR DESCRIPTION
Updates the README to reflect that this module is no longer required for latest Nuxt/Nitro projects.

As confirmed by @pi0 in [besidka/besidka#57](https://github.com/besidka/besidka/pull/57#issuecomment-3814320104), the latest versions of Nitro (v2 and v3) have built-in support for Cloudflare development emulation (using the same Wrangler proxy mechanism).